### PR TITLE
fix(outputs): conditionally output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,12 +1,12 @@
 output "role_id" {
   description = "AWS Role ID"
-  value       = aws_iam_role.role[0].id
+  value       = var.enabled ? aws_iam_role.role[0].id : ""
   sensitive   = false
 }
 
 output "role_arn" {
   description = "AWS Role ARN"
-  value       = aws_iam_role.role[0].arn
+  value       = var.enabled ? aws_iam_role.role[0].arn : ""
   sensitive   = false
 }
 


### PR DESCRIPTION
This pull request makes a minor improvement to the output handling in the Terraform module. The change ensures that the `role_id` and `role_arn` outputs return empty strings when the module is disabled, preventing potential errors or confusion.

* Conditional logic added to `role_id` and `role_arn` outputs in `outputs.tf` so they return empty strings if `var.enabled` is false.